### PR TITLE
feat: inline category assignment directly from Top Channels list

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -386,3 +386,127 @@ body {
 #btnGitHub:hover { color: #24292E; }
 #btnBug:hover    { color: #DC2626; border-color: #FCA5A5; background: #FEF2F2; }
 #btnFeature:hover{ color: #D97706; border-color: #FCD34D; background: #FFFBEB; }
+
+/* ── Inline tag-assignment button (replaces static badge) ─── */
+
+.channel-tag-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 5px 2px 7px;
+  border-radius: 99px;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.4;
+  margin-top: 2px;
+  transition: filter var(--transition), opacity var(--transition);
+}
+.channel-tag-btn:hover  { filter: brightness(0.9); }
+.channel-tag-btn:active { transform: scale(0.95); }
+
+.tag-btn-chevron { flex-shrink: 0; opacity: 0.7; }
+
+/* Untagged state — dashed, inviting */
+.channel-tag-btn.is-untagged {
+  background: transparent !important;
+  color: var(--text-muted) !important;
+  border: 1.5px dashed var(--border);
+  padding: 1px 5px 1px 7px;
+  filter: none;
+}
+.channel-tag-btn.is-untagged:hover {
+  border-color: var(--accent);
+  color: var(--accent) !important;
+  background: var(--accent-soft) !important;
+}
+
+/* ── Tag dropdown panel ──────────────────────────────────── */
+
+.tag-dropdown {
+  position: fixed;
+  z-index: 9999;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0,0,0,.13), 0 2px 6px rgba(0,0,0,.07);
+  overflow: hidden;
+  animation: tagDdIn 110ms ease;
+}
+
+@keyframes tagDdIn {
+  from { opacity: 0; transform: translateY(-5px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0)   scale(1);    }
+}
+
+/* Scrollable list of existing categories */
+.tag-dd-list {
+  max-height: 172px;
+  overflow-y: auto;
+}
+
+.tag-dd-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 80ms ease;
+}
+.tag-dd-item:hover         { background: var(--bg); }
+.tag-dd-item.active        { color: var(--accent); }
+.tag-dd-item.remove        { color: var(--text-muted); font-weight: 400; font-size: 12px; }
+.tag-dd-item.remove:hover  { background: #FEF2F2; color: #EF4444; }
+
+.tag-dd-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.tag-dd-check { margin-left: auto; flex-shrink: 0; color: var(--accent); }
+
+.tag-dd-divider { height: 1px; background: var(--border); margin: 2px 0; }
+
+/* "No categories" message */
+.tag-dd-empty {
+  padding: 10px 12px 6px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Create-new input row at the bottom of the dropdown */
+.tag-dd-create {
+  padding: 6px 8px 8px;
+  border-top: 1px solid var(--border);
+}
+
+.tag-dd-input {
+  width: 100%;
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg);
+  outline: none;
+  transition: border-color var(--transition), background var(--transition);
+}
+.tag-dd-input:focus {
+  border-color: var(--accent);
+  background: var(--surface);
+}
+.tag-dd-input::placeholder { color: var(--text-muted); }

--- a/popup.js
+++ b/popup.js
@@ -191,12 +191,20 @@ function renderChannels(agg, channels, tags) {
 
   container.innerHTML = '';
   for (const [cid, secs] of sorted) {
-    const ch      = channels[cid] || { name: cid, tag: null };
-    const name    = ch.name || cid;
-    const tag     = ch.tag || 'Untagged';
-    const color   = tags[tag]?.color || '#9CA3AF';
-    const initial = name.charAt(0).toUpperCase();
-    const bgColor = avatarColor(name);
+    const ch         = channels[cid] || { name: cid, tag: null };
+    const name       = ch.name || cid;
+    const tag        = ch.tag || null;
+    const isUntagged = !tag;
+    const color      = tag ? (tags[tag]?.color || '#9CA3AF') : null;
+    const initial    = name.charAt(0).toUpperCase();
+    const bgColor    = avatarColor(name);
+
+    // Badge is a button: styled when tagged, dashed call-to-action when not
+    const badgeStyle = isUntagged ? '' : `background:${color}22;color:${color}`;
+    const badgeClass = isUntagged ? 'channel-tag-btn is-untagged' : 'channel-tag-btn';
+    const badgeLabel = isUntagged ? '+ Tag' : tag;
+
+    const chevronSvg = `<svg class="tag-btn-chevron" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>`;
 
     const row = document.createElement('div');
     row.className = 'channel-row';
@@ -204,12 +212,143 @@ function renderChannels(agg, channels, tags) {
       <div class="channel-avatar" style="background:${bgColor}">${initial}</div>
       <div class="channel-info">
         <div class="channel-name">${name}</div>
-        <span class="channel-tag-badge" style="background:${color}22;color:${color}">${tag}</span>
+        <button class="${badgeClass}" style="${badgeStyle}" data-cid="${cid}">
+          ${badgeLabel}${chevronSvg}
+        </button>
       </div>
       <span class="channel-time">${fmtSeconds(secs)}</span>
     `;
     container.appendChild(row);
+
+    // Open dropdown on badge click (re-read storage for freshness)
+    row.querySelector('.channel-tag-btn').addEventListener('click', e => {
+      e.stopPropagation();
+      chrome.storage.local.get(['tags', 'channels']).then(raw => {
+        const freshTags     = raw.tags     || {};
+        const freshChannels = raw.channels || {};
+        const currentTag    = freshChannels[cid]?.tag || null;
+        openTagDropdown(cid, currentTag, freshTags, e.currentTarget);
+      });
+    });
   }
+}
+
+// ── Inline tag dropdown ───────────────────────────────────────
+
+// Palette used when auto-creating a tag from the dropdown input
+const AUTO_COLORS = ['#F97316','#3B82F6','#8B5CF6','#10B981','#F59E0B','#06B6D4','#EF4444','#EC4899'];
+
+function colorForTagName(name) {
+  let h = 0;
+  for (const c of name) h = (h * 31 + c.charCodeAt(0)) & 0xFFFF;
+  return AUTO_COLORS[Math.abs(h) % AUTO_COLORS.length];
+}
+
+let _dropdown        = null;
+let _clickAwayFn     = null;
+let _keyEscFn        = null;
+
+function closeDropdown() {
+  _dropdown?.remove();
+  _dropdown = null;
+  if (_clickAwayFn) { document.removeEventListener('click', _clickAwayFn); _clickAwayFn = null; }
+  if (_keyEscFn)    { document.removeEventListener('keydown', _keyEscFn);  _keyEscFn    = null; }
+}
+
+function openTagDropdown(cid, currentTag, tags, badgeBtn) {
+  closeDropdown();
+
+  const tagEntries  = Object.entries(tags);
+  const hasCategories = tagEntries.length > 0;
+
+  // ── Build dropdown HTML ──
+  let inner = '';
+
+  if (hasCategories) {
+    inner += '<div class="tag-dd-list">';
+    for (const [name, meta] of tagEntries) {
+      const isActive = currentTag === name;
+      const check    = isActive
+        ? `<svg class="tag-dd-check" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>`
+        : '';
+      inner += `<button class="tag-dd-item${isActive ? ' active' : ''}" data-tag="${name}">
+        <span class="tag-dd-dot" style="background:${meta.color}"></span>${name}${check}
+      </button>`;
+    }
+    if (currentTag) {
+      inner += `<div class="tag-dd-divider"></div>
+        <button class="tag-dd-item remove" data-tag="">Remove tag</button>`;
+    }
+    inner += '</div>';
+  } else {
+    inner += `<div class="tag-dd-empty">No categories yet.<br>Type a name to create one.</div>`;
+  }
+
+  inner += `<div class="tag-dd-create">
+    <input class="tag-dd-input" placeholder="${hasCategories ? '+ New category…' : 'Category name…'}" />
+  </div>`;
+
+  // ── Create & position the element ──
+  _dropdown = document.createElement('div');
+  _dropdown.className = 'tag-dropdown';
+  _dropdown.innerHTML = inner;
+  document.body.appendChild(_dropdown);
+
+  // Position below (or above if near the bottom)
+  const rect       = badgeBtn.getBoundingClientRect();
+  const ddHeight   = _dropdown.offsetHeight || 180;
+  const spaceBelow = window.innerHeight - rect.bottom - 8;
+  const top = spaceBelow >= ddHeight
+    ? rect.bottom + 4
+    : rect.top - ddHeight - 4;
+
+  let left = rect.left;
+  const ddWidth = 196;
+  if (left + ddWidth > window.innerWidth - 8) left = window.innerWidth - ddWidth - 8;
+
+  Object.assign(_dropdown.style, { top: top + 'px', left: left + 'px', width: ddWidth + 'px' });
+
+  // ── Wire up existing-category clicks ──
+  _dropdown.querySelectorAll('.tag-dd-item').forEach(btn => {
+    btn.addEventListener('click', () => assignTagToChannel(cid, btn.dataset.tag, badgeBtn));
+  });
+
+  // ── Wire up create-new input ──
+  const input = _dropdown.querySelector('.tag-dd-input');
+  input.focus();
+  input.addEventListener('keydown', async e => {
+    if (e.key === 'Enter') {
+      const name = input.value.trim();
+      if (name) await createAndAssignTag(cid, name, badgeBtn);
+    }
+  });
+
+  // ── Click-away & Escape to close ──
+  setTimeout(() => {
+    _clickAwayFn = e => { if (!_dropdown?.contains(e.target)) closeDropdown(); };
+    _keyEscFn   = e => { if (e.key === 'Escape') closeDropdown(); };
+    document.addEventListener('click',   _clickAwayFn);
+    document.addEventListener('keydown', _keyEscFn);
+  }, 0);
+}
+
+async function assignTagToChannel(cid, tagName, badgeBtn) {
+  closeDropdown();
+  await chrome.runtime.sendMessage({ type: 'SET_CHANNEL_TAG', channelId: cid, tag: tagName });
+  render(currentPeriod); // re-render so category bars update too
+}
+
+async function createAndAssignTag(cid, tagName, badgeBtn) {
+  const raw  = await chrome.storage.local.get('tags');
+  const tags = raw.tags || {};
+
+  // Create tag with auto-color if it doesn't already exist
+  if (!tags[tagName]) {
+    tags[tagName] = { color: colorForTagName(tagName) };
+    await chrome.storage.local.set({ tags });
+  }
+
+  await assignTagToChannel(cid, tagName, badgeBtn);
 }
 
 // ── Main render ──────────────────────────────────────────────


### PR DESCRIPTION
Instead of routing users to Settings to tag a channel, they can now assign (or create) a category with a single click right inside the popup.

UX changes:
- "Untagged" static badge → dashed "+ Tag" button (clear call-to-action)
- Tagged channels show their category as a clickable pill with a chevron
- Clicking either opens a positioned dropdown with: • Existing categories listed with colour dots + checkmark on current • "Remove tag" option when a tag is already assigned • Inline text input at the bottom to create a brand-new category on the spot
- No categories yet? Empty-state message + focused input shown immediately; pressing Enter creates the tag (auto-colour from name hash) and assigns it
- Click-away and Escape both close the dropdown
- After any assignment the full popup re-renders so category bars update live

Code changes — popup.js:
- renderChannels(): replace <span class="channel-tag-badge"> with interactive <button class="channel-tag-btn"> that re-reads storage on click for freshness
- openTagDropdown(): builds & positions the fixed dropdown panel
- closeDropdown(): cleans up element + document event listeners
- assignTagToChannel(): persists via SET_CHANNEL_TAG message, triggers re-render
- createAndAssignTag(): writes new tag to storage then delegates to assignTagToChannel

Code changes — popup.css:
- .channel-tag-btn / .is-untagged — interactive badge styles
- .tag-dropdown, .tag-dd-* — dropdown panel, list items, divider, empty state, create-input; uses existing CSS variables throughout

https://claude.ai/code/session_01M31k4a69MFDtFhg5qVbb6L