### PR TITLE
fix: capture e.currentTarget synchronously before async storage call

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -220,14 +220,18 @@ function renderChannels(agg, channels, tags) {
     `;
     container.appendChild(row);
 
-    // Open dropdown on badge click (re-read storage for freshness)
+    // Open dropdown on badge click (re-read storage for freshness).
+    // IMPORTANT: capture the element reference synchronously — e.currentTarget
+    // is reset to null by the browser once the event handler returns, so it
+    // must not be read inside the async .then() callback.
     row.querySelector('.channel-tag-btn').addEventListener('click', e => {
       e.stopPropagation();
+      const btn = e.currentTarget; // capture before any await / .then()
       chrome.storage.local.get(['tags', 'channels']).then(raw => {
         const freshTags     = raw.tags     || {};
         const freshChannels = raw.channels || {};
         const currentTag    = freshChannels[cid]?.tag || null;
-        openTagDropdown(cid, currentTag, freshTags, e.currentTarget);
+        openTagDropdown(cid, currentTag, freshTags, btn);
       });
     });
   }
@@ -256,6 +260,8 @@ function closeDropdown() {
 }
 
 function openTagDropdown(cid, currentTag, tags, badgeBtn) {
+  if (!badgeBtn) return; // element was unmounted before the storage call resolved
+
   closeDropdown();
 
   const tagEntries  = Object.entries(tags);


### PR DESCRIPTION
Root cause: e.currentTarget is read inside a .then() callback. The DOM spec resets Event.currentTarget to null the moment the synchronous event handler returns, so by the time chrome.storage.local.get() resolves the value is already null — causing the TypeError at getBoundingClientRect().

Fix 1 (popup.js:229) — capture the button reference into a local `btn` variable at the top of the click handler, before the async call, while the event object is still live.

Fix 2 (popup.js:263) — early-return guard in openTagDropdown() so that if the element is ever null for any other reason the function fails silently instead of throwing an uncaught TypeError.

https://claude.ai/code/session_01M31k4a69MFDtFhg5qVbb6L